### PR TITLE
Send empty commands if no button pressed

### DIFF
--- a/packages/virtual_joystick/scripts/virtual_joystick_gui.py
+++ b/packages/virtual_joystick/scripts/virtual_joystick_gui.py
@@ -155,8 +155,7 @@ def loop():
             veh_standing = False
 
         # publish message
-        if (not veh_standing) or force_joy_publish:
-            pub_joystick.publish(msg)
+        pub_joystick.publish(msg)
 
         # adjust veh_standing such that when vehicle stands still, at least
         # one last publishment was sent to the bot. That's why this adjustment


### PR DESCRIPTION
Problem:

(old behavior) When we don't press any button, no message is sent. The pipeline is blocked when using the fifos and we can't receive new images

Fix:

(New behavior) If no command is pressed, send empty message. This unblocks the fifos. I believe this is also what is happening on the `cli` version and with a real controller