### PR TITLE
Ente-DTSW-7240-Investigate-and-resolve-error-with-rqt_image_view-in-Duckietown

### DIFF
--- a/dependencies-apt.txt
+++ b/dependencies-apt.txt
@@ -56,3 +56,5 @@ libxrender1
 libfontconfig1
 
 libgirepository1.0-dev
+
+python3-pyqt5

--- a/dependencies-py3.txt
+++ b/dependencies-py3.txt
@@ -1,7 +1,6 @@
 # LIST YOUR PYTHON3 PACKAGES HERE
 
 # Map editor
-PyQt5==5.14.1
 pynput==1.7.1
 git+https://github.com/OSLL/lib-dt-maps.git@ente
 


### PR DESCRIPTION
This pull request updates the dependencies required for the project, specifically addressing the installation method for the `PyQt5` package. The most important changes are grouped below:

Dependency installation updates:

* Added `python3-pyqt5` to the `dependencies-apt.txt` file to install the system package for PyQt5, ensuring compatibility and potentially simplifying environment setup.
* Removed the `PyQt5==5.14.1` entry from `dependencies-py3.txt`, indicating that PyQt5 will now be installed via the system package manager rather than pip.