### PR TITLE
Fix web VNC app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -204,13 +204,5 @@ RUN ln -sf /usr/local/lib/web/frontend/static/websockify \
 # configure novnc
 ENV HTTP_PORT=8087
 
-# get the image_pipeline (this is needed to avoid issues with python2 shebang)
-RUN git clone https://github.com/ros-perception/image_pipeline.git --branch noetic
-
 # uninstall opencv-python-headless as it obscures opencv-python
 RUN pip3 uninstall --yes opencv-python-headless
-
-# build packages
-RUN . /opt/ros/${ROS_DISTRO}/setup.sh && \
-  catkin build \
-    --workspace ${CATKIN_WS_DIR}/

--- a/Dockerfile
+++ b/Dockerfile
@@ -144,9 +144,6 @@ COPY assets/vnc/image /
 ##
 ##
 # Use architecture-aware base image based on ARCH argument
-ARG ARCH
-ARG NOVNC_VERSION
-ARG WEBSOCKIFY_VERSION
 
 # Map ARCH to Docker platform format and use appropriate base image
 # ARCH 'amd64' -> 'linux/amd64', ARCH 'arm64v8' -> 'linux/arm64'

--- a/assets/vnc/image/etc/nginx/sites-enabled/default
+++ b/assets/vnc/image/etc/nginx/sites-enabled/default
@@ -25,6 +25,7 @@ server {
 	location / {
 		rewrite /approot/(.*) /$1 break;
 		root /usr/local/lib/web/frontend/;
+		try_files $uri $uri/ /index.html;
 	}
 
 	location @apiwebsocket {

--- a/assets/vnc/image/etc/supervisor/conf.d/supervisord.conf
+++ b/assets/vnc/image/etc/supervisor/conf.d/supervisord.conf
@@ -52,5 +52,5 @@ command=x11vnc -display :99 -xkb -forever -shared -repeat -capslock
 [program:novnc]
 priority=25
 directory=/usr/local/lib/web/frontend/static/novnc
-command=bash /usr/local/lib/web/frontend/static/novnc/utils/launch.sh --listen 6081
+command=bash /usr/local/lib/web/frontend/static/novnc/utils/novnc_proxy --listen 6081
 stopasgroup=true

--- a/assets/vnc/web/src/components/Vnc.vue
+++ b/assets/vnc/web/src/components/Vnc.vue
@@ -144,7 +144,7 @@ export default {
         if (!port) {
           port = window.location.protocol[4] === 's' ? 443 : 80
         }
-        let url = 'static/vnc.html?'
+        let url = 'static/novnc/vnc.html?'
         url += 'autoconnect=1&'
         url += `host=${hostname}&port=${port}&`
         url += `path=${websockifyPath}&title=novnc2&`

--- a/assets/vnc/web/src/components/Vnc.vue
+++ b/assets/vnc/web/src/components/Vnc.vue
@@ -70,17 +70,17 @@ export default {
         this.stateID = body.data.id
 
         // adaptive resolution
-        if (!body.data.config.fixedResolution && body.data.config.sizeChangedCount === 0) {
-          const response = await this.$http.get('api/reset', {params: params})
-          const body = response.data
-          if (body.code !== 200) {
-            this.stateErrorCount += 1
-            if (this.stateErrorCount > 10) {
-              this.errorMessage = this.$t('serviceIsUnavailable')
-              throw this.errorMessage
-            }
-          }
-        }
+        //if (!body.data.config.fixedResolution && body.data.config.sizeChangedCount === 0) {
+        //  const response = await this.$http.get('api/reset', {params: params})
+        //  const body = response.data
+        //  if (body.code !== 200) {
+        //    this.stateErrorCount += 1
+        //    if (this.stateErrorCount > 10) {
+        //      this.errorMessage = this.$t('serviceIsUnavailable')
+        //      throw this.errorMessage
+        //    }
+        //  }
+        //}
 
         if (this.vncState === 'stopped') {
           this.reconnect(false)

--- a/dependencies-apt.txt
+++ b/dependencies-apt.txt
@@ -6,11 +6,6 @@ ros-noetic-rqt-tf-tree
 ros-noetic-image-geometry
 python3-pygame
 
-# We are using camera-calibration from source
-# to prevent python2 shebang error
-# NOTE: this should go once camera-calibration is fixed upstream
-# camera-calibration requirements:
-ros-noetic-camera-calibration-parsers
 ros-noetic-camera-info-manager
 libgtk-3-dev
 ros-noetic-tf2-geometry-msgs

--- a/launchers/vnc.sh
+++ b/launchers/vnc.sh
@@ -41,6 +41,8 @@ if [ -n "${RESOLUTION-}" ]; then
     sed -i "s/1024x768/$RESOLUTION/" /usr/local/bin/xvfb.sh
 fi
 
+echo "Line 44"
+
 USER=${USER:-root}
 if [ "$USER" != "root" ]; then
     echo "* enable custom user: $USER"
@@ -59,9 +61,13 @@ sed -i -e "s|%USER%|$USER|" -e "s|%HOME%|$HOME|" /etc/supervisor/conf.d/supervis
 
 # home folder
 if [ ! -x "$HOME/.config/pcmanfm/LXDE/" ]; then
-    mkdir -p $HOME/.config/pcmanfm/LXDE/
-    ln -sf /usr/local/share/wallpapers/desktop-items-0.conf $HOME/.config/pcmanfm/LXDE/
-    chown -R $USER:$USER $HOME
+    mkdir -p "$HOME/.config/pcmanfm/LXDE/"
+    ln -sf /usr/local/share/wallpapers/desktop-items-0.conf "$HOME/.config/pcmanfm/LXDE/"
+
+    # avoid heavy chown when running as root
+    if [ "$USER" != "root" ]; then
+        chown -R "$USER:$USER" "$HOME"
+    fi
 fi
 
 # nginx workers


### PR DESCRIPTION
Improve static file serving, update the noVNC launch process, and clean up legacy or problematic code.

**Frontend and Static File Serving Improvements:**

* Updated Nginx routing.
* Changed the VNC frontend to load `static/novnc/vnc.html` instead of `static/vnc.html`, aligning with the new static file structure.

**noVNC Launch and Supervisor Configuration:**

* Changed supervisor configuration to launch `novnc_proxy` directly instead of using the older `launch.sh` script

**Codebase Cleanup and Dependency Updates:**

* Cleaned up Dockerfile and dependencies by removing unused build steps and legacy camera calibration.

## Testing

1. Clone my fork of the [duckietown-shell-commands](https://github.com/Tuxliri/duckietown-shell-commands) repo and checkout the `use-parsed-distro-in-dts-code-vnc-command-DTSW-7385` branch ([here](https://github.com/Tuxliri/duckietown-shell-commands/tree/use-parsed-distro-in-dts-code-vnc-command-DTSW-7385)).
2. Clone this branch of the `dt-gui-tools` and build it using `dts devel build`
3. Run `dts code vnc` in any `ente` lx (for example the control lx available [here](https://github.com/duckietown/lx-control))
4. Follow the onscreen instructions to open the VNC viewer (if the page does not load correctly you might need to reload the page with SHIFT+CMD+R for it to load).